### PR TITLE
feat(auth): implement JWT-based authentication using Passport.js

### DIFF
--- a/backend-medic/package-lock.json
+++ b/backend-medic/package-lock.json
@@ -29,6 +29,7 @@
         "@types/express": "^4.17.21",
         "@types/jsonwebtoken": "^9.0.9",
         "@types/node": "^22.15.2",
+        "@types/passport-jwt": "^4.0.1",
         "nodemon": "^3.1.10",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
@@ -1008,6 +1009,38 @@
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/passport": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.17.tgz",
+      "integrity": "sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
+    "node_modules/@types/passport-jwt": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/passport-jwt/-/passport-jwt-4.0.1.tgz",
+      "integrity": "sha512-Y0Ykz6nWP4jpxgEUYq8NoVZeCQPo1ZndJLfapI249g1jHChvRfZRO/LS3tqu26YgAS/laI1qx98sYGz0IalRXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "*",
+        "@types/passport-strategy": "*"
+      }
+    },
+    "node_modules/@types/passport-strategy": {
+      "version": "0.2.38",
+      "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.38.tgz",
+      "integrity": "sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/passport": "*"
       }
     },
     "node_modules/@types/qs": {

--- a/backend-medic/package-lock.json
+++ b/backend-medic/package-lock.json
@@ -16,10 +16,12 @@
         "dotenv": "^16.3.1",
         "express": "^4.21.2",
         "graphql": "^16.6.0",
+        "graphql-tag": "^2.12.6",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^7.3.4",
         "passport": "^0.7.0",
-        "passport-jwt": "^4.0.1"
+        "passport-jwt": "^4.0.1",
+        "zod": "^3.24.3"
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
@@ -1853,6 +1855,21 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -3454,6 +3471,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
+      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/backend-medic/package.json
+++ b/backend-medic/package.json
@@ -18,10 +18,12 @@
     "dotenv": "^16.3.1",
     "express": "^4.21.2",
     "graphql": "^16.6.0",
+    "graphql-tag": "^2.12.6",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^7.3.4",
     "passport": "^0.7.0",
-    "passport-jwt": "^4.0.1"
+    "passport-jwt": "^4.0.1",
+    "zod": "^3.24.3"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/backend-medic/package.json
+++ b/backend-medic/package.json
@@ -31,6 +31,7 @@
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.9",
     "@types/node": "^22.15.2",
+    "@types/passport-jwt": "^4.0.1",
     "nodemon": "^3.1.10",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",

--- a/backend-medic/src/config/passport.ts
+++ b/backend-medic/src/config/passport.ts
@@ -1,0 +1,23 @@
+import { Strategy as JwtStrategy,ExtractJwt } from "passport-jwt";
+import passport from "passport";
+import { User } from "../domain/users/models/user.model";
+import dotenv from 'dotenv';
+ dotenv.config();
+
+const options={
+    jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+  secretOrKey: process.env.JWT_SECRET || 'myverysecretkey',
+
+}
+
+passport.use(
+    new JwtStrategy(options, async(jwt_payload, done)=>{
+        try {
+            const user = await User.findById(jwt_payload.id);
+            if (user) return done(null, user);
+            else return done(null, false);
+          } catch (err) {
+            return done(err, false);
+          }
+    })
+)

--- a/backend-medic/src/domain/users/validation/userValidation.ts
+++ b/backend-medic/src/domain/users/validation/userValidation.ts
@@ -1,0 +1,7 @@
+import {z} from 'zod';
+
+export const signupSchema=z.object({
+    username: z.string().min(3,'Username must be at least 3 characters'),
+    email: z.string().email('Invalid email address'),
+    password: z.string().min(6, 'Password must be at least 6 characters')
+});

--- a/backend-medic/src/graphql/resolvers/userResolvers.ts
+++ b/backend-medic/src/graphql/resolvers/userResolvers.ts
@@ -1,4 +1,5 @@
 import { User } from '../../domain/users/models/user.model'; 
+import { signupSchema } from '../../domain/users/validation/userValidation';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 const SECRET = process.env.JWT_SECRET || 'myverysecretkey';
@@ -12,7 +13,8 @@ export const userResolvers= {
     },
     Mutation:{
         signup: async (_:any, args:{username:string, email:string, password:string})=>{
-            const { username,email,password}= args;
+            const validatedData=signupSchema.parse(args);
+            const {username, email, password}= validatedData;
             
       //check email
       const existingUser= await User.findOne({email});


### PR DESCRIPTION
This pull request introduces a complete implementation of user authentication using Passport.js with the JWT strategy in a GraphQL + Apollo Server + Express setup.

✅ Major changes:
Passport configuration with passport-jwt strategy in config/passport.ts

Integrated Passport into the Apollo Server context (in app.ts)

Updated me query resolver to extract authenticated user from JWT

Added proper token signing and user creation logic in the signup mutation

Added validation using yup for the signup flow

📁 Affected files:
src/config/passport.ts

src/graphql/resolvers/userResolvers.ts

src/app.ts

src/domain/users/models/user.model.ts

src/domain/users/validation/userValidation.ts

📌 How to test:
Start the dev server: npm run dev

Register a new user using the signup mutation in Altair

Copy the returned JWT token

Go to the Headers tab in Altair → add:

json
Copy
Edit
{
  "authorization": "Bearer <your_token>"
}
Test me query – should return the authenticated user’s info.

📚 Additional Notes:
Token expires in 7 days ({ expiresIn: '7d' })

Next step (if required): refresh token strategy or user roles (admin/user)

