### PR TITLE
feat: implement user signup with email verification via JWT

### DIFF
--- a/backend-medic/.env.development
+++ b/backend-medic/.env.development
@@ -2,5 +2,5 @@ MONGODB_URI=mongodb://localhost:27017/medic-app
 PORT=3333
 JWT_SECRET=myverysecretkey
 
-EMAIL_USER=your-email@gmail.com
+EMAIL_USER=soraya.medic@gmail.com
 EMAIL_PASS=your-app-password

--- a/backend-medic/src/app.ts
+++ b/backend-medic/src/app.ts
@@ -10,7 +10,7 @@ import './config/passport'
 
 import { userTypeDefs as typeDefs } from './graphql/typeDefs';
 import { resolvers } from './graphql/resolvers';
-
+import {verifyAccountHandler} from './domain/users/controllers/verifyAccountHandler'
 dotenv.config({path: '.env.development'});
 
 async function startServer() {
@@ -38,6 +38,8 @@ async function startServer() {
       });
     },
   }));
+
+  app.get('/verify-account', verifyAccountHandler);
 
   app.get('/', (_req, res) => {
     res.send('🚀 Server is running! Visit /graphql');

--- a/backend-medic/src/domain/users/controllers/verifyAccountHandler.ts
+++ b/backend-medic/src/domain/users/controllers/verifyAccountHandler.ts
@@ -1,0 +1,33 @@
+import { Request,Response } from "express";
+import  jwt  from "jsonwebtoken";
+import {User} from '../models/user.model';
+
+export const verifyAccountHandler= async (req:Request, res:Response)=>{
+    const {token}= req.query;
+
+    if(!token || typeof token!== 'string'){
+        return res.status(400).send('Invalid or missing token');
+    }
+
+    try{
+        const decoded= jwt.verify(token, process.env.JWT_SECRET!)as {id:string};
+
+        const user= await User.findById(decoded.id);
+        if(!user){
+            return res.status(404).send('USER not found');
+        }
+
+        if (user.isVerified){
+            return res.send('Your account is already verified.')
+        }
+        
+        user.isVerified=true;
+        await user.save();
+
+        return res.send('✅ Your account has been successfully verified!');
+
+    }catch(error){
+        return  res.status(400).send('Invalid or expired token');
+    }
+    
+}

--- a/backend-medic/src/graphql/resolvers/userResolvers.ts
+++ b/backend-medic/src/graphql/resolvers/userResolvers.ts
@@ -25,6 +25,13 @@ export const userResolvers= {
       if(existingUser){
         throw new Error('Email is already in use')
       }
+
+      // ✅ Check username
+      const existingUsername = await User.findOne({ username });
+      if (existingUsername) {
+      throw new Error('Username is already in use');
+      }
+      
      //Step3: hashedPassword
       const hashedPassword = await bcrypt.hash(password, 10);
 

--- a/backend-medic/src/graphql/resolvers/userResolvers.ts
+++ b/backend-medic/src/graphql/resolvers/userResolvers.ts
@@ -47,6 +47,7 @@ export const userResolvers= {
       
       //Step7: Create login token(valid for 7days)
       const token = jwt.sign({ id: user.id }, SECRET, { expiresIn: '7d' });
+      console.log('✅ verificationToken:', verificationToken);
 
       // result
       return {

--- a/backend-medic/src/routes/verifyAccount.ts
+++ b/backend-medic/src/routes/verifyAccount.ts
@@ -1,0 +1,23 @@
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import {User} from '../domain/users/models/user.model';
+
+const router=express.Router();
+router.get('/verify-account',async(req,res)=>{
+    const token= req.query.token as string;
+    if(!token){
+        return res.status(400).send('Verification token is missing');}
+    try{
+    const payload=jwt.verify(token,process.env.JWT_SECRET!) as {id:string};
+    const user=await User.findById(payload.id);
+    if(!user){
+        return res.status(404).send('User not found');
+    }
+    user.isVerified=true;
+    await user.save();
+    return res.send('✅ Account verified successfully!')
+}catch(err){
+    return res.status(400).send('Invalid or expired token')
+}
+});
+export default router;

--- a/backend/.env.development
+++ b/backend/.env.development
@@ -3,3 +3,5 @@ MONGODB_URI=mongodb+srv://sorayamahmoudi95:0foVhMUdTFlAdbDn@cluster0.jauaqqu.mon
 
 PORT=3333
 JWT_SECRET=myverysecretkey
+EMAIL_USER=your-email@gmail.com
+EMAIL_PASS=your-app-password


### PR DESCRIPTION
This PR adds the user registration functionality with full email verification flow.

🔹 Validates input using Zod schema (`signupSchema`)
🔹 Checks for existing email and username
🔹 Hashes password with bcrypt
🔹 Creates JWT verification token (expires in 1 hour)
🔹 Sends verification link via nodemailer using Gmail SMTP
🔹 Logs token for development testing
🔹 Includes `/verify-account` route to handle token verification

✅ Test instructions:
- Send `signup` mutation via Altair with email, username, password
- Copy verification token from console
- Open http://localhost:3333/verify-account?token=YOUR_TOKEN_HERE

💡 Note: Make sure `.env.development` includes:
